### PR TITLE
Remove envvars, build a simple kwargs structure

### DIFF
--- a/docs/api/util.mv.md
+++ b/docs/api/util.mv.md
@@ -6,4 +6,4 @@ The matrix-vector module provides utilities for matrix-free operations with matr
 
 ::: laplax.util.mv.diagonal
 
-::: laplax.util.mv.todense
+::: laplax.util.mv.to_dense

--- a/docs/api/util.ops.md
+++ b/docs/api/util.ops.md
@@ -2,20 +2,6 @@
 
 The operations module provides utilities for flexible and adaptive computation, including environment variable management and batch processing.
 
-## Environment Utilities
-
-::: laplax.util.ops.str_to_bool
-
-::: laplax.util.ops.get_env_value
-
-::: laplax.util.ops.get_env_int
-
-::: laplax.util.ops.get_env_bool
-
 ## Adaptive Operations
-
-::: laplax.util.ops.lmap
-
-::: laplax.util.ops.laplax_dtype
 
 ::: laplax.util.ops.precompute_list

--- a/laplax/curv/cov.py
+++ b/laplax/curv/cov.py
@@ -27,7 +27,7 @@ from laplax.util.flatten import (
     wrap_factory,
     wrap_function,
 )
-from laplax.util.mv import diagonal, todense
+from laplax.util.mv import diagonal, to_dense
 from laplax.util.tree import get_size
 
 # -----------------------------------------------------------------------
@@ -63,7 +63,7 @@ def create_full_curvature(
     else:
         flatten, unflatten = create_pytree_flattener(layout)
         mv_wrapped = wrap_function(mv, input_fn=unflatten, output_fn=flatten)
-    curv_est = todense(mv_wrapped, layout=get_size(layout))
+    curv_est = to_dense(mv_wrapped, layout=get_size(layout))
     return curv_est
 
 

--- a/laplax/curv/ggn.py
+++ b/laplax/curv/ggn.py
@@ -129,7 +129,6 @@ def create_ggn_mv_without_data(
     factor=Float,
     *,
     has_batch: bool = True,
-    **kwargs,
 ) -> Callable[[Params, Data], Params]:
     r"""Create Generalized Gauss-Newton (GGN) matrix-vector productwithout fixed data.
 
@@ -148,8 +147,6 @@ def create_ggn_mv_without_data(
         loss_fn: Loss function to use for the GGN computation.
         factor: Scaling factor for the GGN computation.
         has_batch: Whether the data has a batch dimension.
-        **kwargs: Additional arguments, including:
-            - `lmap_ggn_mv`: Chunk size for iterating over data.
 
     Returns:
         A function that takes a vector and a batch of data, and computes the GGN
@@ -158,8 +155,6 @@ def create_ggn_mv_without_data(
     Note:
         The function assumes that the data has a batch dimension.
     """
-    del kwargs
-
     # Create loss Hessian-vector product
     loss_fn_hessian_mv = create_loss_hessian_mv(loss_fn)
     if has_batch:
@@ -191,10 +186,8 @@ def create_ggn_mv(
     params: Params,
     data: Data,
     loss_fn: LossFn | str | Callable,
-    # loss_scaling_factor: Float = 1.0,
     num_curv_samples: Int | None = None,
     num_total_samples: Int | None = None,
-    **kwargs,
 ) -> Callable[[Params], Params]:
     r"""Computes the Generalized Gauss-Newton (GGN) matrix-vector product with data.
 
@@ -222,8 +215,6 @@ def create_ggn_mv(
         num_total_samples: Number of total samples the model was trained on. See the
             remark in `num_ggn_samples`'s description. Defaults to None, in which case
             it is set to equal `num_ggn_samples`.
-        **kwargs: Additional arguments, including:
-            - `lmap_ggn_mv`: Chunk size for iterating over data.
 
     Returns:
         A function that takes a vector and computes the GGN matrix-vector product for
@@ -231,13 +222,6 @@ def create_ggn_mv(
 
     Note: The function assumes a batch dimension.
     """
-    # if not isinstance(loss_fn, Callable) and loss_scaling_factor != 1.0:
-    #     msg = (
-    #         "invalid scaling factor provided; "
-    #         "built-in losses use `loss_scaling_factor = 1"
-    #     )
-    #     raise ValueError(msg)
-
     if num_curv_samples is None:
         num_curv_samples = data["input"].shape[0]
 
@@ -251,7 +235,6 @@ def create_ggn_mv(
         params=params,
         loss_fn=loss_fn,
         factor=curv_scaling_factor,
-        **kwargs,
     )
 
     def wrapped_ggn_mv(vec: Params) -> Params:

--- a/laplax/eval/calibrate.py
+++ b/laplax/eval/calibrate.py
@@ -21,7 +21,6 @@ from loguru import logger
 
 from laplax.eval.metrics import estimate_q
 from laplax.types import Array, Data, Float, PriorArguments
-from laplax.util.ops import laplax_dtype
 
 
 # Calibrate prior
@@ -190,7 +189,6 @@ def optimize_prior_prec(
         start=log_prior_prec_min,
         stop=log_prior_prec_max,
         num=grid_size,
-        dtype=laplax_dtype(),
     )
     prior_prec = grid_search(
         prior_prec_interval,

--- a/laplax/util/mv.py
+++ b/laplax/util/mv.py
@@ -7,7 +7,6 @@ import jax.numpy as jnp
 
 from laplax import util
 from laplax.types import Array, Layout, PyTree
-from laplax.util.ops import lmap
 from laplax.util.tree import (
     basis_vector_from_index,
     eye_like,
@@ -67,7 +66,7 @@ def diagonal(mv: Callable | jnp.ndarray, layout: Layout | None = None) -> Array:
     ])
 
 
-def todense(mv: Callable, layout: Layout, **kwargs) -> Array:
+def to_dense(mv: Callable, layout: Layout, **kwargs) -> Array:
     """Generate a dense matrix representation from a matrix-vector product function.
 
     Converts a matrix-vector product function into its equivalent dense matrix form
@@ -80,7 +79,7 @@ def todense(mv: Callable, layout: Layout, **kwargs) -> Array:
             - PyTree: The structure for input to the MVP.
             - None: Defaults to an identity-like structure.
         **kwargs: Additional options:
-            - `lmap_dense`: Batch size for applying the MVP function.
+            - `to_dense_batch_size`: Batch size for applying the MVP function.
 
     Returns:
         jax.Array: A dense matrix representation of the MVP function.
@@ -98,5 +97,6 @@ def todense(mv: Callable, layout: Layout, **kwargs) -> Array:
         raise TypeError(msg)
 
     return jax.tree.map(
-        jnp.transpose, lmap(mv, identity, batch_size=kwargs.get("lmap_dense", "mv"))
-    )  # Lmap shares along the first axis (rows instead of columns).
+        jnp.transpose,
+        jax.lax.map(mv, identity, batch_size=kwargs.get("to_dense_batch_size")),
+    )  # jax.lax.map shares along the first axis (rows instead of columns).

--- a/laplax/util/ops.py
+++ b/laplax/util/ops.py
@@ -1,12 +1,10 @@
 """Contains operations for flexible/adaptive compute."""
 
 import operator
-import os
 
 import jax
-import jax.numpy as jnp
 
-from laplax.types import Callable, DType, Iterable
+from laplax.types import Callable, Iterable
 
 # -------------------------------------------------------------------------
 # Default values

--- a/laplax/util/ops.py
+++ b/laplax/util/ops.py
@@ -40,73 +40,9 @@ def str_to_bool(value: str) -> bool:
     return valid_values[value]
 
 
-def get_env_value(key: str, default: int | str | None = None) -> str | None:
-    """Fetch the value of an environment variable or return a default value.
-
-    Args:
-        key: The name of the environment variable.
-        default: The default value to return if the variable is not set.
-
-    Returns:
-        str: The value of the environment variable or the default.
-    """
-    if default is not None:
-        default = str(default)
-    return os.getenv(key, default)
-
-
-def get_env_int(key: str, default: int | None = None) -> int | None:
-    """Fetch the value of an environment variable as an integer.
-
-    Args:
-        key: The name of the environment variable.
-        default: The default integer value to return if the variable is not set.
-
-    Returns:
-        int: The value of the environment variable as an integer.
-    """
-    val = get_env_value(key, default)
-    if val is not None:
-        val = int(val)
-    return val
-
-
-def get_env_bool(key: str, default: str | None = None) -> bool | None:
-    """Fetch the value of an environment variable as a boolean.
-
-    Args:
-        key: The name of the environment variable.
-        default: The default string value ("True" or "False") if the variable is not
-            set.
-
-    Returns:
-        bool: The value of the environment variable as a boolean.
-
-    Raises:
-        ValueError: If the default string is not a valid boolean representation.
-    """
-    val = get_env_value(key, default)
-    if val is not None:
-        val = str_to_bool(val)
-    return val
-
-
 # -------------------------------------------------------------------------
 # Adaptive operations
 # -------------------------------------------------------------------------
-
-
-def laplax_dtype() -> DType:
-    """Get the data type (dtype) used by the library.
-
-    This function retrieves the dtype specified by the "LAPLAX_DTYPE" environment
-    variable or returns the default dtype.
-
-    Returns:
-        DType: The JAX-compatible dtype to use.
-    """
-    dtype = get_env_value("LAPLAX_DTYPE", DEFAULT_DTYPE)
-    return jnp.dtype(dtype)
 
 
 def precompute_list(

--- a/laplax/util/ops.py
+++ b/laplax/util/ops.py
@@ -6,15 +6,15 @@ import os
 import jax
 import jax.numpy as jnp
 
-from laplax.types import Any, Callable, DType, Iterable
+from laplax.types import Callable, DType, Iterable
 
 # -------------------------------------------------------------------------
 # Default values
 # -------------------------------------------------------------------------
 
-DEFAULT_PARALLELISM = 32
+DEFAULT_PARALLELISM = None
 DEFAULT_DTYPE = "float32"
-DEFAULT_PRECOMPUTE_LIST = "True"
+DEFAULT_PRECOMPUTE_LIST = True
 
 # -------------------------------------------------------------------------
 # Utilities
@@ -96,34 +96,6 @@ def get_env_bool(key: str, default: str | None = None) -> bool | None:
 # -------------------------------------------------------------------------
 
 
-def lmap(func: Callable, data: Iterable, batch_size: int | str | None = None) -> Any:
-    """Apply a function over an iterable with support for batching.
-
-    This function maps `func` over `data`, splitting the data into batches
-    determined by the `batch_size`.
-
-    Args:
-        func: The function to apply to each element or batch of the data.
-        data: The input iterable over which to map the function.
-        batch_size: The batch size for processing. Options:
-            - None: Use the default batch size specified by the environment.
-            - str: Determine the batch size from an environment variable.
-            - int: Specify the batch size directly.
-
-    Returns:
-        Any: The result of mapping `func` over `data`.
-    """
-    if isinstance(batch_size, str):
-        batch_size = get_env_int(f"LAPLAX_PARALLELISM_{batch_size.upper()}", None)
-    elif batch_size is None:
-        batch_size = get_env_int("LAPLAX_PARALLELISM", DEFAULT_PARALLELISM)
-        if batch_size is None:
-            msg = "LAPLAX_PARALLELISM environment variable not set properly."
-            raise ValueError(msg)
-
-    return jax.lax.map(func, data, batch_size=batch_size)
-
-
 def laplax_dtype() -> DType:
     """Get the data type (dtype) used by the library.
 
@@ -138,7 +110,7 @@ def laplax_dtype() -> DType:
 
 
 def precompute_list(
-    func: Callable, items: Iterable, option: str | bool | None = None, **kwargs
+    func: Callable, items: Iterable, precompute: bool | None = None, **kwargs
 ) -> Callable:
     """Precompute results for a list of items or return the original function.
 
@@ -148,28 +120,22 @@ def precompute_list(
     Args:
         func: The function to apply to each item in the list.
         items: An iterable of items to process.
-        option: Determines whether to precompute results:
+        precompute: Determines whether to precompute results:
             - None: Use the default precompute setting.
-            - str: Retrieve the setting from an environment variable.
             - bool: Specify directly whether to precompute.
         **kwargs: Additional keyword arguments, including:
-            - lmap_precompute: Batch size for precomputing results.
+            - precompute_list_batch_size: Batch size for precomputing results.
 
     Returns:
         Callable: A function to retrieve precomputed elements by index, or the original
         `func` if precomputation is disabled.
     """
-    if isinstance(option, str):
-        option = get_env_bool(f"LAPLAX_PRECOMPUTE_LIST_{option}", None)
-    elif option is None:
-        option = get_env_bool("LAPLAX_PRECOMPUTE_LIST", DEFAULT_PRECOMPUTE_LIST)
-        if option is None:
-            msg = "LAPLAX_PRECOMPUTE_LIST environment variable not set properly."
-            raise ValueError(msg)
+    if precompute is None:
+        precompute = DEFAULT_PRECOMPUTE_LIST
 
-    if option:
-        precomputed = lmap(
-            func, items, batch_size=kwargs.get("lmap_precompute", "precompute")
+    if precompute:
+        precomputed = jax.lax.map(
+            func, items, batch_size=kwargs.get("precompute_list_batch_size")
         )
 
         def get_element(index: int):

--- a/laplax/util/tree.py
+++ b/laplax/util/tree.py
@@ -10,7 +10,6 @@ import jax.numpy as jnp
 
 from laplax.types import Any, Array, Callable, Float, KeyType, PyTree
 from laplax.util.flatten import unravel_array_into_pytree
-from laplax.util.ops import lmap
 
 # ---------------------------------------------------------------
 # Tree utilities
@@ -336,7 +335,9 @@ def eye_like_with_basis_vector(tree: PyTree) -> PyTree:
         A PyTree of basis vectors.
     """
     num_elems = get_size(tree)
-    return lmap(partial(basis_vector_from_index, tree=tree), jnp.arange(num_elems))
+    return jax.lax.map(
+        partial(basis_vector_from_index, tree=tree), jnp.arange(num_elems)
+    )
 
 
 def eye_like(tree: PyTree) -> PyTree:

--- a/tests/test_curv/test_cov.py
+++ b/tests/test_curv/test_cov.py
@@ -95,7 +95,7 @@ def test_posterior_covariance_est(task):
 
     # Get and test scale matrix
     scale_mv = CURVATURE_STATE_TO_SCALE[task.method](state)
-    scale_dense = util.mv.todense(scale_mv, layout=task.tree_like)
+    scale_dense = util.mv.to_dense(scale_mv, layout=task.tree_like)
     assert jnp.allclose(
         scale_dense @ scale_dense.T @ prec_dense,
         jnp.eye(task.size),
@@ -105,7 +105,7 @@ def test_posterior_covariance_est(task):
 
     # Get and test covariance matrix
     cov_mv = CURVATURE_STATE_TO_COV[task.method](state)
-    cov_dense = util.mv.todense(cov_mv, layout=task.tree_like)
+    cov_dense = util.mv.to_dense(cov_mv, layout=task.tree_like)
     assert jnp.allclose(
         cov_dense @ prec_dense, jnp.eye(task.size), atol=1e-2, rtol=1e-2
     )

--- a/tests/test_curv/test_curv_linear_regression.py
+++ b/tests/test_curv/test_curv_linear_regression.py
@@ -9,7 +9,7 @@ from laplax.curv.ggn import create_ggn_mv
 from laplax.curv.hessian import create_hessian_mv
 from laplax.enums import LossFn
 from laplax.util.flatten import create_pytree_flattener, wrap_function
-from laplax.util.mv import todense
+from laplax.util.mv import to_dense
 from laplax.util.tree import get_size
 
 
@@ -38,7 +38,7 @@ def test_ggn_linear_regression():
         num_total_samples=N,
     )
 
-    G_calc = todense(ggn_mv, layout=params).swapaxes(0, 1).reshape(-1, D_out * D_in)
+    G_calc = to_dense(ggn_mv, layout=params).swapaxes(0, 1).reshape(-1, D_out * D_in)
 
     # Compare results
     np.testing.assert_allclose(G_manual, G_calc, atol=5 * 1e-6)
@@ -74,7 +74,7 @@ def test_ggn_linear_regression_2():
     flatten, unflatten = create_pytree_flattener(state)
     ggn_mv = wrap_function(ggn_mv, input_fn=unflatten, output_fn=flatten)
     num_params = get_size(state)
-    G = todense(ggn_mv, layout=num_params)
+    G = to_dense(ggn_mv, layout=num_params)
 
     # Compare results
     G_manual = (
@@ -113,7 +113,7 @@ def test_hessian_linear_regression():
     )
 
     hessian_calc = (
-        todense(hessian_mv, layout=params).swapaxes(0, 1).reshape(-1, D_out * D_in)
+        to_dense(hessian_mv, layout=params).swapaxes(0, 1).reshape(-1, D_out * D_in)
     )
 
     # Compare results
@@ -151,7 +151,7 @@ def test_hessian_linear_regression_2():
     flatten, unflatten = create_pytree_flattener(state)
     hessian_mv = wrap_function(hessian_mv, input_fn=unflatten, output_fn=flatten)
     num_params = get_size(state)
-    H = todense(hessian_mv, layout=num_params)
+    H = to_dense(hessian_mv, layout=num_params)
 
     # Compare results
     hessian_manual = (

--- a/tests/test_curv/test_ggn.py
+++ b/tests/test_curv/test_ggn.py
@@ -8,7 +8,6 @@ import pytest_cases
 
 from laplax.curv.ggn import create_ggn_mv, create_loss_hessian_mv
 from laplax.enums import LossFn
-from laplax.util.ops import lmap
 
 from .cases.rosenbrock import RosenbrockCase
 
@@ -98,7 +97,7 @@ def test_ggn_rosenbrock(rosenbrock):
     )
 
     # Compute the GGN
-    ggn_calc = lmap(ggn_mv, jnp.eye(2))
+    ggn_calc = jax.lax.map(ggn_mv, jnp.eye(2))
 
     # Compare with the manual GGN
     ggn_manual = rosenbrock.ggn_manual

--- a/tests/test_curv/test_hessian.py
+++ b/tests/test_curv/test_hessian.py
@@ -1,9 +1,9 @@
+import jax
 import jax.numpy as jnp
 import pytest
 import pytest_cases
 
 from laplax.curv.hessian import create_hessian_mv
-from laplax.util.ops import lmap
 
 from .cases.rosenbrock import RosenbrockCase
 
@@ -28,6 +28,6 @@ def test_hessian_rosenbrock(rosenbrock):
         num_total_samples=1,
     )
 
-    hessian_calc = lmap(hessian_mv, jnp.eye(2))
+    hessian_calc = jax.lax.map(hessian_mv, jnp.eye(2))
     hessian_manual = rosenbrock.hessian_manual
     assert jnp.allclose(hessian_calc, hessian_manual)

--- a/tests/test_laplace_regression.py
+++ b/tests/test_laplace_regression.py
@@ -333,14 +333,6 @@ def test_compare_implementations_against_laplace_redux(
     mean_diff_lin = np.abs(torch_mu_lin - laplax_mu_lin).mean()
     std_diff_lin = np.abs(torch_std_lin - laplax_std_lin).mean()
 
-    # print("===== Non-linear Laplace Comparison =====")
-    # print("Mean predictions difference:", mean_diff_nonlin)
-    # print("Std predictions difference:", std_diff_nonlin)
-
-    # print("===== Linear Laplace Comparison =====")
-    # print("Mean predictions difference:", mean_diff_lin)
-    # print("Std predictions difference:", std_diff_lin)
-
     np.testing.assert_allclose(mean_diff_nonlin, 0, atol=1)
     np.testing.assert_allclose(std_diff_nonlin, 0, atol=1)
     np.testing.assert_allclose(mean_diff_lin, 0, atol=1e-4)

--- a/tests/test_laplace_regression.py
+++ b/tests/test_laplace_regression.py
@@ -21,7 +21,7 @@ from laplax.eval.pushforward import (
     set_nonlin_pushforward,
 )
 from laplax.util.flatten import create_pytree_flattener, wrap_function
-from laplax.util.mv import todense
+from laplax.util.mv import to_dense
 
 
 def get_sinusoid_example(n_data=150, sigma_noise=0.3, batch_size=150):
@@ -371,7 +371,7 @@ def test_ggn_against_curvlinops(trained_laplace_comparison):
         num_total_samples=1,
     )
     flatten, unflatten = create_pytree_flattener(la_case.params)
-    jax_ggn = todense(
+    jax_ggn = to_dense(
         wrap_function(ggn_mv, unflatten, flatten), layout=flatten(la_case.params)
     )
 

--- a/tests/test_util/test_mv.py
+++ b/tests/test_util/test_mv.py
@@ -4,7 +4,7 @@ import numpy as np
 import pytest
 
 from laplax.util.flatten import create_pytree_flattener, wrap_function
-from laplax.util.mv import diagonal, todense
+from laplax.util.mv import diagonal, to_dense
 from laplax.util.tree import get_size
 
 
@@ -20,7 +20,7 @@ def test_diagonal_dense(n):
 
 
 @pytest.mark.parametrize("n", [2, 5])
-def test_diagonal_and_todense_flat_mvp(n):
+def test_diagonal_and_to_dense_flat_mvp(n):
     key = jax.random.PRNGKey(42)
     A = jax.random.normal(key, (n, n))
 
@@ -32,13 +32,13 @@ def test_diagonal_and_todense_flat_mvp(n):
     diag_expected = jnp.diag(A)
     np.testing.assert_allclose(diag_computed, diag_expected, atol=1e-7, rtol=1e-7)
 
-    # 2) Compare todense(mv, layout=n) to A
-    dense_computed = todense(mv, layout=n)
+    # 2) Compare to_dense(mv, layout=n) to A
+    dense_computed = to_dense(mv, layout=n)
     np.testing.assert_allclose(dense_computed, A, atol=1e-7, rtol=1e-7)
 
 
 @pytest.mark.parametrize(("n1", "n2"), [(2, 3), (3, 4)])
-def test_diagonal_and_todense_pytree_mvp(n1, n2):
+def test_diagonal_and_to_dense_pytree_mvp(n1, n2):
     key = jax.random.PRNGKey(999)
     layout = {
         "x": jnp.zeros(n1),
@@ -75,13 +75,13 @@ def test_diagonal_and_todense_pytree_mvp(n1, n2):
     diag_expected = jnp.diag(A)
     np.testing.assert_allclose(diag_computed, diag_expected, atol=1e-7, rtol=1e-7)
 
-    # 2) Compare todense(mv, layout=layout) to A
-    dense_computed = todense(mv, layout)
+    # 2) Compare to_dense(mv, layout=layout) to A
+    dense_computed = to_dense(mv, layout)
 
     flatten, unflatten = create_pytree_flattener(layout)
     np.testing.assert_allclose(flatten(dense_computed).reshape(*A.shape), A)
 
     mv_wrapped = wrap_function(mv, input_fn=unflatten, output_fn=flatten)
-    dense_computed = todense(mv_wrapped, get_size(layout))
+    dense_computed = to_dense(mv_wrapped, get_size(layout))
     flatten, unflatten = create_pytree_flattener(layout)
     np.testing.assert_allclose(flatten(dense_computed).reshape(*A.shape), A)


### PR DESCRIPTION
This PR removes environment variable handling from `laplax`. In turn, it introduces a much simpler kwargs structure to specify batch sizes and other parameters. (No expressivity is lost.)

There were multiple envvars that were unreachable from the main API - these are now also easy to set up via kwargs. Some docstrings were also outdated - now, we have a mostly coherent set of docstrings. The documentation has been updated accordingly. Some defaults have also been changed, as they went against the "as performance-oriented as possible" mindset of `laplax`.

Reasons I removed envvars:
- Hard to understand as a user: envvars only give further confusion, with cascading behavior that is hard to track across functions. The library is not enormous s.t. we couldn't use kwargs instead, which is much more Pythonic.
- Inconsistent: sometimes, the fallback value was 'as performance-oriented as possible', e.g., `DEFAULT_PRECOMPUTE_LIST = True`. But sometimes, the fallback was an arbitrary value, like `CHUNK_SIZE = 32`, instead of a full-batch behavior.
- Harmful for reproducibility: script runtime and potentially output depend not only on values specified in the script but also on the runtime environment.
- Unusual way to set numerical values in a Python script. For example, JAX uses envvars, but mostly for compiler flags and logs - not for providing arguments to the script like the batch size.
- If we want to group defaults based on use cases (like "mv"), we can still do this with kwargs (and is done so in this PR).

`lmap` becomes a one-liner this way, so one can directly use `jax.lax.map` - a function that users reading the source will be more familiar with.