### PR TITLE
fixed bug in create_partial_pytree_flattener in unflatten function

### DIFF
--- a/laplax/util/flatten.py
+++ b/laplax/util/flatten.py
@@ -104,7 +104,7 @@ def create_partial_pytree_flattener(
     def unflatten(arr: jax.Array) -> PyTree:
         flat_vector_split = jnp.split(
             arr, cumsum(math.prod(sh[:-1]) for sh in all_shapes)[:-1], axis=0
-        )  # Ignore row indices in shape.
+        )  # Ignore column indices in shape.
         return jax.tree_util.tree_unflatten(
             tree_def,
             [

--- a/laplax/util/flatten.py
+++ b/laplax/util/flatten.py
@@ -103,7 +103,7 @@ def create_partial_pytree_flattener(
 
     def unflatten(arr: jax.Array) -> PyTree:
         flat_vector_split = jnp.split(
-            arr, cumsum(math.prod(sh[1:]) for sh in all_shapes)[:-1], axis=1
+            arr, cumsum(math.prod(sh[:-1]) for sh in all_shapes)[:-1], axis=0
         )  # Ignore row indices in shape.
         return jax.tree_util.tree_unflatten(
             tree_def,


### PR DESCRIPTION
For the following example:
```python
example_tree = jax.tree.map(lambda n: n, {"x": jnp.eye(10), "y": jnp.eye(10)})
flattener, unflattener = create_partial_pytree_flattener(example_tree)
flattened = flattener(simple_tree)
unflattened = unflattener(flattened)
```
I obtain the following error message.

```---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
Cell In[4], line 3
      1 flattener, unflattener = create_partial_pytree_flattener(example_tree)
      2 flattened = flattener(example_tree)
----> 3 unflattened = unflattener(flattened)

File ~/repos/laplax/laplax/util/flatten.py:110, in create_partial_pytree_flattener.<locals>.unflatten(arr)
    104 def unflatten(arr: jax.Array) -> PyTree:
    105     flat_vector_split = jnp.split(
    106         arr, cumsum(math.prod(sh[1:]) for sh in all_shapes)[:-1], axis=1
    107     )  # Ignore row indices in shape.
    108     return jax.tree_util.tree_unflatten(
    109         tree_def,
--> 110         [
    111             flat_vector_split[i].reshape(all_shapes[i])
    112             for i in range(len(flat_vector_split))
    113         ],
    114     )

File ~/repos/laplax/laplax/util/flatten.py:111, in <listcomp>(.0)
    104 def unflatten(arr: jax.Array) -> PyTree:
    105     flat_vector_split = jnp.split(
    106         arr, cumsum(math.prod(sh[1:]) for sh in all_shapes)[:-1], axis=1
    107     )  # Ignore row indices in shape.
    108     return jax.tree_util.tree_unflatten(
    109         tree_def,
    110         [
--> 111             flat_vector_split[i].reshape(all_shapes[i])
    112             for i in range(len(flat_vector_split))
    113         ],
    114     )


File ~/repos/laplax/.venv/lib/python3.11/site-packages/jax/_src/numpy/array_methods.py:470, in _compute_newshape(arr, newshape)
    467 else:
    468   if (all(isinstance(d, int) for d in (*arr.shape, *newshape)) and
    469       arr.size != math.prod(newshape)):
--> 470     raise TypeError(f"cannot reshape array of shape {arr.shape} (size {arr.size}) "
    471                     f"into shape {orig_newshape} (size {math.prod(newshape)})")
    472 return tuple(-core.divide_shape_sizes(arr.shape, newshape)
    473              if core.definitely_equal(d, -1) else d for d in newshape)

TypeError: cannot reshape array of shape (20, 10) (size 200) into shape (10, 10) (size 100)
```

This was fixed by changing the axis argument in flatten.py in line 106 from 
`axis=1` to `axis=0` and the range of shapes from `sh[1:]` to `sh[:-1]`.


