### PR TITLE
Add missing tqdm dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
     "Programming Language :: Python :: 3 :: Only",
     "Operating System :: OS Independent",
 ]
-dependencies = ["jax", "jaxtyping", "loguru"]
+dependencies = ["jax", "jaxtyping", "loguru", "tqdm"]
 description = "Laplace approximations in JAX."
 dynamic = ["version"]
 keywords = [
@@ -47,12 +47,7 @@ dev = [
     "curvlinops-for-pytorch",
     "laplace-torch",
 ]
-notebooks = [
-    "torch",
-    "torchvision",
-    "optax",
-    "flax",
-]
+notebooks = ["torch", "torchvision", "optax", "flax"]
 docs = [
     "mkdocs",
     "mkdocs-material",
@@ -229,7 +224,7 @@ ignore = [
 
 [tool.ruff.lint.extend-per-file-ignores]
 "tests/*.py" = ["S101"] # Use of assert is allowed in test files
-"*.ipynb" = ["T201"]  # Print statements are fine in notebooks
+"*.ipynb" = ["T201"] # Print statements are fine in notebooks
 
 [tool.ruff.lint.mccabe]
 max-complexity = 18


### PR DESCRIPTION
`tqdm` got added in [this commit](https://github.com/laplax-org/laplax/commit/36ea98935f2e92d6cbae66d0d259d3e3b8ebad64) but isn't currently included in the dependencies. This commit fixes this.