### PR TITLE
Fix bug in DataLoaderMV

### DIFF
--- a/laplax/util/loader.py
+++ b/laplax/util/loader.py
@@ -324,18 +324,17 @@ class DataLoaderMV:
                 wrap_function(
                     partial(self.mv, data=data),
                     input_fn=self.input_transform,
+                    output_fn=self.output_transform,
                 ),
                 **kwargs,
             )
 
-        return self.output_transform(
-            process_batches(
-                _body_fn,
-                self.loader,
-                transform=self.transform,
-                reduce=self.reduce,
-                verbose_logging=self.verbose_logging,
-            )
+        return process_batches(
+            _body_fn,
+            self.loader,
+            transform=self.transform,
+            reduce=self.reduce,
+            verbose_logging=self.verbose_logging,
         )
 
 


### PR DESCRIPTION
`input_transform` and `output_transform` should be be applied to the input "vector" in a matrix-vector product and the output of the matrix-vector product respectively. In the current implementation of `DataLoaderMV`, the `input_transform` is being applied correctly, but the `output_transform` isn't applied to the output of the matrix-vector product, but instead to the output of the function being "lowered" in `lower_func`. For instance, currently it could be applied to the output of `to_dense`, instead of a matrix-vector product.