### PR TITLE
Documentation updates

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,3 +60,4 @@ uv run mkdocs serve
 ```
 
 This starts a local development server you can view at http://127.0.0.1:8000. If you want to add a new example notebook, make sure to convert it to `.py` format using `jupytext` as described above, and place it in the `examples` directory. When the docs are built, the notebook will be run and converted to `.md` format automatically and placed in an `_examples` directory. In order to link to the notebook in the documentation, make sure to add it to the `Examples` section under `nav` in the `mkdocs.yml` file.
+If you don't want to execute the example notebooks everytime the docs are built locally, comment the line `- docs/convert_examples.py` in `mkdocs.yml`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,4 +60,4 @@ uv run mkdocs serve
 ```
 
 This starts a local development server you can view at http://127.0.0.1:8000. If you want to add a new example notebook, make sure to convert it to `.py` format using `jupytext` as described above, and place it in the `examples` directory. When the docs are built, the notebook will be run and converted to `.md` format automatically and placed in an `_examples` directory. In order to link to the notebook in the documentation, make sure to add it to the `Examples` section under `nav` in the `mkdocs.yml` file.
-If you don't want to execute the example notebooks everytime the docs are built locally, comment the line `- docs/convert_examples.py` in `mkdocs.yml`.
+If you don't want to execute the example notebooks everytime the docs are built locally, temporarily comment the line `- docs/convert_examples.py` in `mkdocs.yml`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,4 +60,4 @@ uv run mkdocs serve
 ```
 
 This starts a local development server you can view at http://127.0.0.1:8000. If you want to add a new example notebook, make sure to convert it to `.py` format using `jupytext` as described above, and place it in the `examples` directory. When the docs are built, the notebook will be run and converted to `.md` format automatically and placed in an `_examples` directory. In order to link to the notebook in the documentation, make sure to add it to the `Examples` section under `nav` in the `mkdocs.yml` file.
-If you don't want to execute the example notebooks everytime the docs are built locally, temporarily comment the line `- docs/convert_examples.py` in `mkdocs.yml`.
+If you don't want to execute the example notebooks every time the docs are built locally, temporarily comment out the line `- docs/convert_examples.py` in `mkdocs.yml`.

--- a/README.md
+++ b/README.md
@@ -28,4 +28,4 @@ The development of `laplax` is guided by the following principles:
 - **PyTree-Centric Structure:** Internally, the package is structured around PyTrees. This design choice allows us to defer materialization until necessary, optimizing performance and memory usage.
 
 ## Roadmap and Contributions
-We're developing this package in public, and discussions about the roadmap and feature priorities are structured in the [Issues](https://github.com/bmucsanyi/laplax/issues) section. If you're interested in contributing or want to see what's planned for the future, please check them out.
+We're developing this package in public, and discussions about the roadmap and feature priorities are structured in the [Issues](https://github.com/bmucsanyi/laplax/issues) section. If you're interested in contributing or want to see what's planned for the future, please check them out. Also, have a look at the [Contributing.md](https://github.com/laplax-org/laplax/blob/main/CONTRIBUTING.md).

--- a/README.md
+++ b/README.md
@@ -28,4 +28,4 @@ The development of `laplax` is guided by the following principles:
 - **PyTree-Centric Structure:** Internally, the package is structured around PyTrees. This design choice allows us to defer materialization until necessary, optimizing performance and memory usage.
 
 ## Roadmap and Contributions
-We're developing this package in public, and discussions about the roadmap and feature priorities are structured in the [Issues](https://github.com/bmucsanyi/laplax/issues) section. If you're interested in contributing or want to see what's planned for the future, please check them out. Also, have a look at the [Contributing.md](https://github.com/laplax-org/laplax/blob/main/CONTRIBUTING.md).
+We're developing this package in public, and discussions about the roadmap and feature priorities are structured in the [Issues](https://github.com/bmucsanyi/laplax/issues) section. If you're interested in contributing or want to see what's planned for the future, please check them out. Also, have a look at the [CONTRIBUTING.md](https://github.com/laplax-org/laplax/blob/main/CONTRIBUTING.md).

--- a/docs/background.md
+++ b/docs/background.md
@@ -44,7 +44,7 @@ $$
 f_{\theta^{\text{lin}}}(\cdot, \theta) = f_{\theta^*}(\cdot, \theta^*) + \mathcal{J}_{\theta^*}(\cdot)(\theta - \theta^*)
 $$
 
-and using the linear closure of Gaussian distributions[@immer_improving_2021], yielding **closed-form** output-space uncertainty.
+and using the linear closure of Gaussian distributions[@immer_improving_2021], yielding **closed-form** output-space uncertainty.[^1]
 [^1]: For classification, the logit-space uncertainty is analytic, but the predictive distribution has to be approximated, e.g., through Monte Carlo sampling and averaging the softmax probabilities.
 
 The linearised approach is guaranteed to yield positive-definite weight-space covariance matrices for a strictly convex regulariser $\Omega$ at any weight configuration $\theta$, not just at MAP estimates (that are hard to obtain exactly in deep learning settings).

--- a/docs/reference/curv.md
+++ b/docs/reference/curv.md
@@ -7,7 +7,7 @@ Currently supported curvature-vector products are:
 - **GGN-mv (Generalized Gauss-Newton):**
 
     $$
-    v \mapsto \sum_{n=1}^{N} \mathcal{J}_\theta^\top(f_{\theta^*}(x_n)) \nabla^2_{f_{\theta^*}(x_n),f_{\theta^*}(x_n)} \ell(f_\theta(x_n), y_n) \mathcal{J}_\theta(f_{\theta^*})\, v
+    v \mapsto \sum_{n=1}^{N} \mathcal{J}_\theta^\top(f_{\theta^*}(x_n)) \nabla^2_{f_{\theta^*}(x_n),f_{\theta^*}(x_n)} \ell(f_\theta(x_n), y_n) \mathcal{J}_\theta(f_{\theta^*}(x_n))\, v
     $$
 
 - **Hessian-mv (Hessian):**
@@ -15,9 +15,23 @@ Currently supported curvature-vector products are:
     v \mapsto \sum_{n=1}^{N} \nabla_{\theta \theta}^2 \ell(f_\theta(x_n), y_n)\,v
     $$
 
+- **Empirical-Fisher-mv:**
+
+    $$
+    v \mapsto \sum_{n=1}^{N}\mathcal{J}_\theta^\top(f_{\theta^*}(x_n))\nabla_{f_{\theta^*}(x_n)} \ell(f_\theta(x_n), y_n)\nabla_{f_{\theta^*}(x_n)}^\top \ell(f_\theta(x_n), y_n)\mathcal{J}_\theta(f_{\theta^*}(x_n))\, v
+    $$
+
+- **MC-Fisher-mv (Monte-Carlo approximated):**
+
+    $$
+    v \mapsto \sum_{n=1}^{N}\sum_{n=1}^{M}\mathcal{J}_\theta^\top(f_{\theta^*}(x_n))\nabla_{f_{\theta^*}(x_n)}\ell(f_\theta(x_n), \tilde{y}_{n,m})\nabla_{f_{\theta^*}(x_n)}^\top\ell(f_\theta(x_n), \tilde{y}_{n,m})\mathcal{J}_\theta(f_{\theta^*}(x_n))\,v
+    $$
+
+In the latter, $\tilde{y}_{n,m}$ are labels sampled from the likelihood induced by the loss function: $\tilde{y}_{n,m} \sim e^{-\ell(f_\theta(x_n), y)}$
+
 ## Curvature estimators/approximations
 
-For both curvature-vector products, the following methods are supported for approximating and transforming them into a weight space covariance matrix-vector product:
+For all curvature-vector products, the following methods are supported for approximating and transforming them into a weight space covariance matrix-vector product:
 
 - `CurvApprox.FULL` denses the curvature-vector product into a full matrix. The posterior function is then given by
 

--- a/docs/reference/curv.md
+++ b/docs/reference/curv.md
@@ -24,7 +24,7 @@ Currently supported curvature-vector products are:
 - **MC-Fisher-mv (Monte-Carlo approximated):**
 
     $$
-    v \mapsto \sum_{n=1}^{N}\sum_{n=1}^{M}\mathcal{J}_\theta^\top(f_{\theta^*}(x_n))\nabla_{f_{\theta^*}(x_n)}\ell(f_\theta(x_n), \tilde{y}_{n,m})\nabla_{f_{\theta^*}(x_n)}^\top\ell(f_\theta(x_n), \tilde{y}_{n,m})\mathcal{J}_\theta(f_{\theta^*}(x_n))\,v
+    v \mapsto \tfrac{1}{M} \sum_{n=1}^{N}\sum_{m=1}^{M}\mathcal{J}_\theta^\top(f_{\theta^*}(x_n))\nabla_{f_{\theta^*}(x_n)}\ell(f_\theta(x_n), \tilde{y}_{n,m})\nabla_{f_{\theta^*}(x_n)}^\top\ell(f_\theta(x_n), \tilde{y}_{n,m})\mathcal{J}_\theta(f_{\theta^*}(x_n))\,v
     $$
 
 In the latter, $\tilde{y}_{n,m}$ are labels sampled from the likelihood induced by the loss function: $\tilde{y}_{n,m} \sim e^{-\ell(f_\theta(x_n), y)}$

--- a/laplax/curv/fisher.py
+++ b/laplax/curv/fisher.py
@@ -272,7 +272,7 @@ def create_MC_fisher_mv_without_data(
 
     The resulting matrix vector product computes:
     $$
-    \text{factor} \cdot \frac{1}{\text{mc_samples}\sum_n,m J_n^\top \left(\nabla_{f_n}
+    \frac{factor}{\text{mc\_samples}}\sum_{n,m} J_n^\top \left(\nabla_{f_n}
     c(y=\tilde{y}_{n,m},\hat{y}=f_n)\right) \left(\nabla_{f_n}
     c(y=\tilde{y}_{n,m},\hat{y}=f_n)\right)^\top J_n \cdot v
     $$
@@ -367,7 +367,7 @@ def create_MC_fisher_mv(
 
     The resulting matrix vector product computes:
     $$
-    \text{factor} \cdot \frac{1}{\text{mc_samples}\sum_n,m J_n^\top \left(\nabla_{f_n}
+    \text{factor} \cdot \frac{1}{\text{mc\_samples}\sum_n,m J_n^\top \left(\nabla_{f_n}
     c(y=\tilde{y}_{n,m},\hat{y}=f_n)\right) \left(\nabla_{f_n}
     c(y=\tilde{y}_{n,m},\hat{y}=f_n)\right)^\top J_n \cdot v
     $$

--- a/laplax/curv/fisher.py
+++ b/laplax/curv/fisher.py
@@ -367,7 +367,8 @@ def create_MC_fisher_mv(
 
     The resulting matrix vector product computes:
     $$
-    \text{factor} \cdot \frac{1}{\text{mc\_samples}}\sum_{n,m} J_n^\top \left(\nabla_{f_n}
+    \text{factor} \cdot \frac{1}{\text{mc\_samples}}\sum_{n,m}
+    J_n^\top \left(\nabla_{f_n}
     c(y=\tilde{y}_{n,m},\hat{y}=f_n)\right) \left(\nabla_{f_n}
     c(y=\tilde{y}_{n,m},\hat{y}=f_n)\right)^\top J_n \cdot v
     $$

--- a/laplax/curv/fisher.py
+++ b/laplax/curv/fisher.py
@@ -367,7 +367,7 @@ def create_MC_fisher_mv(
 
     The resulting matrix vector product computes:
     $$
-    \text{factor} \cdot \frac{1}{\text{mc\_samples}\sum_n,m J_n^\top \left(\nabla_{f_n}
+    \text{factor} \cdot \frac{1}{\text{mc\_samples}}\sum_{n,m} J_n^\top \left(\nabla_{f_n}
     c(y=\tilde{y}_{n,m},\hat{y}=f_n)\right) \left(\nabla_{f_n}
     c(y=\tilde{y}_{n,m},\hat{y}=f_n)\right)^\top J_n \cdot v
     $$

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -41,6 +41,7 @@ nav:
       - laplax.curv:
         - Overview: reference/curv.md
         - laplax.curv.ggn: reference/curv/ggn.md
+        - laplax.curv.fisher: reference/curv/fisher.md
         - laplax.curv.hessian: reference/curv/hessian.md
         - laplax.curv.full: reference/curv/full.md
         - laplax.curv.diagonal: reference/curv/diagonal.md
@@ -48,6 +49,7 @@ nav:
         - laplax.curv.lanczos: reference/curv/lanczos.md
         - laplax.curv.lobpcg: reference/curv/lobpcg.md
         - laplax.curv.cov: reference/curv/cov.md
+        - laplax.curv.loss: reference/curv/loss.md
         - laplax.curv.utils: reference/curv/utils.md
       - laplax.eval:
         - Overview: reference/eval.md


### PR DESCRIPTION
Update in the documentation to reflect implementation of #59 

- Fix latex in docstrings of Fisher implementation
- Add Fisher curvature descriptions to reference/curv/
- Fixed missing footnote in background.md
- Add reference pages for newly implemented functions
- Add contributing tip to make serving docs locally faster