### PR TITLE
Add warning about found precision at edge of grid search

### DIFF
--- a/laplax/eval/calibrate.py
+++ b/laplax/eval/calibrate.py
@@ -138,6 +138,16 @@ def grid_search(
     best_prior_prec = prior_precs[np.nanargmin(results)]
     logger.info(f"Chosen prior prec = {best_prior_prec:.4f}")
 
+    # Warn if the found precision is at the edge of the grid
+    if (
+        best_prior_prec == prior_prec_interval[0]
+        or best_prior_prec == prior_prec_interval[-1]
+    ):
+        logger.info(
+            "Found precision is at the edge of the grid."
+            " Consider increasing the grid size."
+        )
+
     return best_prior_prec
 
 


### PR DESCRIPTION
Additional logging that I found useful when working with grid search calibration.
When the chosen prior precision is the first or last element of the grid search array, it is very likely that better values lie outside the searched grid. Therefore it would make sense to notify the user about this, in order to increase the search grid.